### PR TITLE
comment, standard, optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Instead try just using `pull.values(array)`.
 
 ## Example
 
-``` js
+```js
 var Pushable = require('pull-pushable')
 var pull     = require('pull-stream')
 var p = Pushable()
@@ -28,7 +28,7 @@ p.end()
 
 Also, can provide a listener for when the stream is closed.
 
-``` js
+```js
 var Pushable = require('pull-pushable')
 var pull     = require('pull-stream')
 var p = Pushable(function (err) {
@@ -42,7 +42,6 @@ p.push(1)
 p.push(2)
 p.push(3)
 p.push(4) //stream will be aborted before this is output
-
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -33,8 +33,15 @@ function pullPushable (onClose) {
 
   read.push = function (data) {
     if (ended) return
-    buffer.push(data)
+    // if sink already waiting,
+    // we can call back directly.
+    if (cb) {
+      callback(abort, data)
+      return
+    }
+    // otherwise push data and
     // attempt to drain
+    buffer.push(data)
     drain()
   }
 

--- a/index.js
+++ b/index.js
@@ -1,48 +1,67 @@
-module.exports = function (onClose) {
-  var buffer = [], ended, abort, cb
+module.exports = pullPushable
 
+function pullPushable (onClose) {
+  // create a buffer for data
+  // that have been pushed
+  // but not yet pulled.
+  var buffer = []
+
+  // a pushable is a source stream
+  // (abort, cb) => cb(end, data)
+  //
+  // when pushable is pulled,
+  // keep references to abort and cb
+  // so we can call back after
+  // .end(end) or .push(data)
+  var abort, cb
+  function read (_abort, _cb) {
+    if (_abort) {
+      abort = _abort
+      // if there is already a cb waiting, abort it.
+      if (cb) callback(abort)
+    }
+    cb = _cb
+    drain()
+  }
+
+  var ended
+  read.end = function (end) {
+    ended = ended || end || true
+    // attempt to drain
+    drain()
+  }
+
+  read.push = function (data) {
+    if (ended) return
+    buffer.push(data)
+    // attempt to drain
+    drain()
+  }
+
+  return read
+
+  // `drain` calls back to (if any) waiting
+  // sink with abort, end, or next data.
+  function drain () {
+    if (!cb) return
+
+    if (abort) callback(abort)
+    else if (!buffer.length && ended) callback(ended)
+    else if (buffer.length) callback(null, buffer.shift())
+  }
+
+  // `callback` calls back to waiting sink,
+  // and removes references to sink cb.
   function callback (err, val) {
     var _cb = cb
-    if(err && onClose) {
+    // if error and pushable passed onClose, call it
+    // the first time this stream ends or errors.
+    if (err && onClose) {
       var c = onClose
       onClose = null
       c(err === true ? null : err)
     }
     cb = null
     _cb(err, val)
-
   }
-
-  function drain() {
-    if(!cb) return
-
-    if(abort)                        callback(abort)
-    else if(!buffer.length && ended) callback(ended)
-    else if(buffer.length)           callback(null, buffer.shift())
-  }
-
-  function read (_abort, _cb) {
-    if(_abort) {
-      abort = _abort
-      //if there is already a cb waiting, abort it.
-      if(cb) callback(abort)
-    }
-    cb = _cb
-    drain()
-  }
-
-  read.push = function (data) {
-    if(ended) return
-    buffer.push(data)
-    drain()
-  }
-
-  read.end = function (end) {
-    ended = ended || end || true;
-    drain()
-  }
-
-  return read
 }
-
-

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   },
   "devDependencies": {
     "pull-stream": "^3.0.1",
-    "tape": "~1.0.2"
+    "standard": "^7.1.2",
+    "tape": "^4.6.0"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "standard && tape test/*.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/test/abort.js
+++ b/test/abort.js
@@ -1,5 +1,4 @@
-
-var pull = require('pull-stream')
+// var pull = require('pull-stream')
 var tape = require('tape')
 var Pushable = require('../')
 
@@ -11,7 +10,7 @@ tape('abort after a read', function (t) {
     t.equal(err, _err)
   })
 
-  //manual read.
+  // manual read.
   p(null, function (err, data) {
     console.log('read cb')
     t.equal(err, _err)
@@ -21,7 +20,6 @@ tape('abort after a read', function (t) {
     console.log('abort cb')
     t.end()
   })
-  
 })
 
 tape('abort without a read', function (t) {
@@ -36,7 +34,6 @@ tape('abort without a read', function (t) {
     console.log('abort cb')
     t.end()
   })
-
 })
 
 tape('abort without a read, with data', function (t) {
@@ -53,5 +50,4 @@ tape('abort without a read, with data', function (t) {
   })
 
   p.push(1)
-
 })

--- a/test/end.js
+++ b/test/end.js
@@ -1,10 +1,8 @@
-
-var pull     = require('pull-stream')
+// var pull = require('pull-stream')
 var pushable = require('../')
-var test     = require('tape')
+var test = require('tape')
 
 test('pushable', function (t) {
-
   var buf = pushable()
   t.plan(10)
 
@@ -34,4 +32,3 @@ test('pushable', function (t) {
     })
   })
 })
-

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,11 @@
-
-var pull     = require('pull-stream')
+var pull = require('pull-stream')
 var pushable = require('../')
-var test     = require('tape')
+var test = require('tape')
 
 test('pushable', function (t) {
-
   var buf = pushable()
 
-  //should be a read function!
+  // should be a read function!
 
   t.equal('function', typeof buf)
   t.equal(2, buf.length)
@@ -21,11 +19,10 @@ test('pushable', function (t) {
     })
   )
 
-  //SOMETIMES YOU NEED PUSH!
+  // SOMETIMES YOU NEED PUSH!
 
   buf.push(1)
   buf.push(2)
   buf.push(3)
   buf.end()
-
 })

--- a/test/take.js
+++ b/test/take.js
@@ -2,13 +2,11 @@ var pull = require('pull-stream')
 var pushable = require('../')
 var test = require('tape')
 
-
 test('on close callback', function (t) {
-
   var i = 0
 
   var p = pushable(function (err) {
-    if(err) throw err
+    if (err) throw err
     console.log('ended', err)
     t.equal(i, 3)
     t.end()
@@ -28,5 +26,4 @@ test('on close callback', function (t) {
   p.push(3)
   p.push(4)
   p.push(5)
-
 })


### PR DESCRIPTION
hey @dominictarr,

here's [your suggestion](https://github.com/Hypercubed/EventsSpeedTests/pull/2#issuecomment-228223419) implemented.

seems to help a bit, before:

```
Theoretical max x 20,120,961 ops/sec ±4.86% (10 runs sampled) *burn in*
MiniSignals x 15,381,183 ops/sec ±2.27% (10 runs sampled)
mini-pipe x 14,867,393 ops/sec ±6.16% (10 runs sampled)
EventEmitter x 13,120,457 ops/sec ±3.63% (10 runs sampled)
MicroSignals x 14,177,460 ops/sec ±15.69% (10 runs sampled)
EventEmitter3 x 12,476,861 ops/sec ±9.58% (10 runs sampled)
signal-lite x 12,015,678 ops/sec ±7.56% (10 runs sampled)
dripEmitter x 11,812,423 ops/sec ±11.84% (10 runs sampled)
EventEmitter2 x 14,187,397 ops/sec ±35.18% (10 runs sampled)
push-stream x 10,881,711 ops/sec ±6.01% (10 runs sampled)
ReactiveProperty x 8,956,755 ops/sec ±8.41% (10 runs sampled)
push-stream-patch x 9,345,109 ops/sec ±14.26% (10 runs sampled)
observ x 6,266,037 ops/sec ±11.30% (10 runs sampled)
RXJS x 3,349,851 ops/sec ±8.77% (10 runs sampled)
event-signal x 2,789,982 ops/sec ±5.97% (10 runs sampled)
barracks x 2,835,602 ops/sec ±14.77% (10 runs sampled)
d3-dispatch x 1,726,163 ops/sec ±7.91% (10 runs sampled)
pull-pushable x 1,587,159 ops/sec ±1.94% (10 runs sampled)
dripEmitterEnhanced x 853,680 ops/sec ±1.51% (10 runs sampled)
pull-notify x 437,368 ops/sec ±4.70% (10 runs sampled)
observable x 481,767 ops/sec ±19.53% (10 runs sampled)
signal-emitter x 342,021 ops/sec ±4.01% (10 runs sampled)
minivents x 279,941 ops/sec ±3.11% (10 runs sampled)
JS-Signals x 245,514 ops/sec ±14.47% (10 runs sampled)
namespace-emitter x 188,021 ops/sec ±2.07% (10 runs sampled)
```

after:

```
Theoretical max x 19,808,549 ops/sec ±3.05% (10 runs sampled) *burn in*
mini-pipe x 15,498,393 ops/sec ±7.05% (10 runs sampled)
MiniSignals x 13,925,170 ops/sec ±1.46% (10 runs sampled)
MicroSignals x 14,271,370 ops/sec ±7.38% (10 runs sampled)
signal-lite x 12,612,094 ops/sec ±8.09% (10 runs sampled)
push-stream x 11,406,447 ops/sec ±5.96% (10 runs sampled)
ReactiveProperty x 9,201,107 ops/sec ±11.20% (10 runs sampled)
push-stream-patch x 9,684,901 ops/sec ±33.43% (10 runs sampled)
EventEmitter x 7,338,195 ops/sec ±4.14% (10 runs sampled)
EventEmitter3 x 9,146,239 ops/sec ±35.05% (10 runs sampled)
dripEmitter x 8,782,591 ops/sec ±30.70% (10 runs sampled)
EventEmitter2 x 8,932,679 ops/sec ±38.77% (10 runs sampled)
observ x 4,372,794 ops/sec ±1.37% (10 runs sampled)
pull-pushable x 3,401,511 ops/sec ±9.42% (10 runs sampled)
event-signal x 3,043,959 ops/sec ±5.05% (10 runs sampled)
barracks x 2,569,803 ops/sec ±5.57% (10 runs sampled)
RXJS x 2,434,372 ops/sec ±6.69% (10 runs sampled)
d3-dispatch x 1,794,338 ops/sec ±4.04% (10 runs sampled)
dripEmitterEnhanced x 979,185 ops/sec ±7.60% (10 runs sampled)
observable x 396,305 ops/sec ±3.06% (10 runs sampled)
pull-notify x 351,958 ops/sec ±3.27% (10 runs sampled)
signal-emitter x 314,840 ops/sec ±4.41% (10 runs sampled)
minivents x 285,241 ops/sec ±5.31% (10 runs sampled)
JS-Signals x 204,678 ops/sec ±1.78% (10 runs sampled)
namespace-emitter x 182,191 ops/sec ±4.99% (10 runs sampled)
```

also standard-ized the overall module code and added comments.
