### PR TITLE
keep es5 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function pullPushable (separated, onClose) {
 
   // Return functions separated from source { push, end, source }
   if (separated) {
-    return { push, end, source: read }
+    return { push: push, end: end, source: read }
   }
 
   // Return normal


### PR DESCRIPTION
using keys as values is es6+. this broke [`pull-stream-docs`](https://github.com/pull-stream/pull-stream-docs)'s build because it uglifies the javascript and uglify breaks on anything beyond es5.

---

note: i'm totally in favor of [a subset of es6+](https://github.com/ahdinosaur/es2040), but i think it's best we keep browser compatibility via es5 or specifying browserify transforms in `package.json`. or at least that's my strategy. another strategy is to pre-transpile before publish (the most popular yet in my opinion most ugly) or expect consumers to transpile with global transforms.