### PR TITLE
Remove dead code path

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,8 @@ function pullPushable (separated, onClose) {
       callback(abort, data)
       return
     }
-    // otherwise push data and
-    // attempt to drain
+    // otherwise buffer data
     buffer.push(data)
-    drain()
   }
 
   // Return functions separated from source { push, end, source }


### PR DESCRIPTION
The `drain` function is only invoked if `cb` is falsy, because the `push` function otherwise would return early. The `drain` function is a no-op if `cb` is falsy. Thus `drain` is always a no-op when invoked.